### PR TITLE
#162163137 Pagination support for articles

### DIFF
--- a/src/__tests__/actions/ArticlesActions.test.js
+++ b/src/__tests__/actions/ArticlesActions.test.js
@@ -34,7 +34,7 @@ it.only('test getArticles action', () => {
   });
   const expectedActions = [
     {
-      payload: [{}],
+      payload: {results: [{}]},
       type: 'GET_ARTICLES'
     }
   ];

--- a/src/__tests__/components/articles/ArticlesFeed.test.js
+++ b/src/__tests__/components/articles/ArticlesFeed.test.js
@@ -41,7 +41,7 @@ describe('Articles component', () => {
     const props = {
       map: jest.fn(),
       getArticles: jest.fn(),
-      articles: { articles: [{ title: 'h', description: 'eeee' }] }
+      articles: { articles: [{ title: 'h', description: 'eeee' }] },
     };
     const component = mount(
       <Router>
@@ -49,6 +49,49 @@ describe('Articles component', () => {
       </Router>
     );
   });
+
+  it('should fetch and display next articles (pagination)', () => {
+    const props = {
+      getArticles: jest.fn(),
+      articles: {articles: [], article: {}, nextPage: '', previousPage: ''},
+      nextPage: '',
+      previousPage: '',
+      article: {}
+    };
+    const wrapper = mount(<Articles {...props} />);
+    const spy = jest.spyOn(wrapper.instance().props, 'getArticles');
+    wrapper.find('#nextPage').simulate('click');
+  });
+
+  it('should fetch and display previous articles (pagination)', () => {
+    const props = {
+      getArticles: jest.fn(),
+      articles: {articles: [], article: {}, nextPage: '', previousPage: ''},
+      nextPage: '',
+      previousPage: '',
+      article: {}
+    };
+    const wrapper = mount(<Articles {...props} />);
+    const spy = jest.spyOn(wrapper.instance().props, 'getArticles');
+    wrapper.find('#previousPage').simulate('click');
+  });
+  it('tests that the component receives new props', () => {
+    const props = {
+      newPost: {},
+      articles:{articles:[]},
+      getArticles: jest.fn(),
+    };
+    const nextProps = {
+      newPost: {},
+      articles:{articles:['author:happy, body:always glad']},
+      getArticles: jest.fn(),
+    };
+    const wrapper = shallow(<Articles {...props} />);
+    wrapper.instance().componentWillReceiveProps(nextProps);
+    expect(wrapper.instance().props).toEqual(props);
+
+  });
+
 });
 
 describe('Single Article component', () => {
@@ -79,4 +122,5 @@ describe('Single Article component', () => {
     wrapper.setProps(props);
     expect(wrapper.state('article')).toEqual({});
   });
+
 });

--- a/src/__tests__/reducers/ArticlesReducer.test.js
+++ b/src/__tests__/reducers/ArticlesReducer.test.js
@@ -10,35 +10,52 @@ import expect from 'expect';
 
 describe('articles reducer', () => {
   it('should return the initial state', () => {
-    expect(articlesReducer(undefined, 
-      {"article": {}, "articles": [], "delete": {}, "errors": {}, "update": {}}
-      )).toEqual({"article": {}, "articles": [], "delete": {}, "errors": {}, "update": {}});
+    expect(
+      articlesReducer(undefined, {
+        article: {},
+        articles: [],
+        delete: {},
+        errors: {},
+        update: {}
+      })
+    ).toEqual({
+      article: {},
+      articles: [],
+      delete: {},
+      errors: {},
+      update: {}
+    });
   });
 
   it('should handle ADD_ARTICLE', () => {
     const createOne = {
-      type: ADD_ARTICLE_SUCCESS,
+      type: ADD_ARTICLE_SUCCESS
     };
     expect(articlesReducer({}, createOne)).toEqual({});
   });
 
   it('should handle GET_ARTICLES', () => {
     const getAll = {
-      type: GET_ARTICLES
+      type: GET_ARTICLES,
+      payload: { results: [], next: '', previous: '' }
     };
-    expect(articlesReducer({}, getAll)).toEqual({});
+    expect(articlesReducer({}, getAll)).toEqual({
+      nextPage: '',
+      previousPage: '',
+      articles: []
+    });
   });
 
   it('should handle EDIT_ARTICLE', () => {
     const upDate = {
-      type: EDIT_ARTICLE,
+      type: EDIT_ARTICLE
     };
     expect(articlesReducer({}, upDate)).toEqual({});
   });
 
   it('should handle DELETE_ARTICLE', () => {
     const successAction = {
-      type: DELETE_ARTICLE,
+      type: DELETE_ARTICLE
     };
     expect(articlesReducer({}, successAction)).toEqual({});
   });

--- a/src/actions/ArticlesActions.js
+++ b/src/actions/ArticlesActions.js
@@ -10,8 +10,13 @@ import {
 const token = window.localStorage.getItem('token');
 const API_HOST_URL = process.env.API_URL;
 
-export const getArticles = () => dispatch => {
-  return fetch(`${API_HOST_URL}/articles/`, {
+export const getArticles = (url = undefined) => dispatch => {
+
+  let path = url;
+  if (!path) {
+    path = `${API_HOST_URL}/articles/`;
+  }
+  return fetch(path, {
     method: 'GET',
     headers: {
       'content-type': 'application/json',
@@ -22,7 +27,7 @@ export const getArticles = () => dispatch => {
     .then(articles => {
       dispatch({
         type: GET_ARTICLES,
-        payload: articles.article.results
+        payload: articles.article
       });
     });
 };
@@ -56,8 +61,6 @@ export const addArticle = payload => dispatch => {
   })
     .then(res => res.json())
     .then(response => {
-      //check if response is successful? dispatch successAction
-      //else if: response has errors? dispatch errorsAction
       if (response.article.errors) {
         dispatch({
           type: ADD_ARTICLE_ERRORS,
@@ -84,8 +87,6 @@ export const editArticle = (slug, payload) => dispatch => {
   })
     .then(res => res.json())
     .then(response => {
-      //check if response is successful? dispatch successAction
-      //else if: response has errors? dispatch errorsAction
       if (response.article.errors) {
         dispatch({
           type: ADD_ARTICLE_ERRORS,

--- a/src/components/articles/ArticlesFeed.js
+++ b/src/components/articles/ArticlesFeed.js
@@ -6,8 +6,13 @@ import PropTypes from 'prop-types';
 import { readingTime } from './ReadTime';
 
 export class Articles extends Component {
+  constructor(props) {
+    super(props);
+    this.next = this.next.bind(this);
+  }
+
   componentDidMount() {
-    this.props.getArticles();
+    this.props.getArticles(`${process.env.API_URL}/articles/`);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -16,7 +21,15 @@ export class Articles extends Component {
     }
   }
 
+  next(url) {
+    if (url === null) {
+      return;
+    }
+    this.props.getArticles(url);
+  }
+
   render() {
+    // console.log(this.props.nextPage)
     const postItem = this.props.articles.articles.map(post => (
       <section id="dashboard-page" className="flex-grow-1" key={post.slug}>
         <section id="articles" className="mt-5 mb-2">
@@ -27,8 +40,6 @@ export class Articles extends Component {
                   <div className="card-body">
                     <h6 className="card-subtitle mb-2 text-muted">
                       {new Date(post.createdAt).toLocaleDateString() +
-                        ' ' +
-                        new Date(post.createdAt).toLocaleTimeString() +
                         ' ' +
                         readingTime(`${post.body}`)}
                     </h6>
@@ -45,7 +56,29 @@ export class Articles extends Component {
         </section>
       </section>
     ));
-    return <div>{postItem}</div>;
+    return (
+      <div>
+        {postItem}
+        <div className="container d-flex flex-row justify-content-end mb-3">
+          <button
+            id="previousPage"
+            className="btn btn-dark mr-1"
+            disabled={this.props.previousPage === null ? true : false}
+            onClick={() => this.props.getArticles(this.props.previousPage)}
+          >
+            Prev
+          </button>
+          <button
+            id="nextPage"
+            className="btn btn-dark"
+            disabled={this.props.nextPage === null ? true : false}
+            onClick={() => this.next(this.props.nextPage)}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    );
   }
 }
 
@@ -58,7 +91,9 @@ Articles.propTypes = {
 const mapStateToProps = state => {
   return {
     articles: state.articles,
-    article: state.article
+    article: state.article,
+    nextPage: state.articles.nextPage,
+    previousPage: state.articles.previousPage
   };
 };
 export default connect(

--- a/src/reducers/ArticlesReducer.js
+++ b/src/reducers/ArticlesReducer.js
@@ -9,8 +9,7 @@ import {
 
 const initialState = {
   articles: [],
-  article: {
-  },
+  article: {},
   update: {},
   delete: {},
   errors: {}
@@ -31,7 +30,9 @@ const articlesReducer = (state = initialState, action) => {
     case GET_ARTICLES:
       return {
         ...state,
-        articles: action.payload
+        articles: action.payload.results,
+        nextPage: action.payload.next,
+        previousPage: action.payload.previous
       };
     case GET_SINGLE_ARTICLE:
       return {


### PR DESCRIPTION
### What does this PR do?
This Pull Request adds pagination support to articles.

#### Description of Task to be completed?
Add pagination to our articles to make article traversal easier.

#### How should this be manually tested?
- Clone the repository then checkout to the branch `ft-pagination-162163137`.
- Install the required dependencies.
     - yarn 
- Start the server.
     - yarn start
- Run the project in the browser.
- Click on the login button on the interface and fill in the details. 
- The articles are displayed on pages and a maximum of 10 per page.

#### What are the relevant pivotal tracker stories?
[#162163137](https://www.pivotaltracker.com/story/show/162163137)